### PR TITLE
AndroidX support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ android:
   components:
     - tools
     - platform-tools
-    - android-27
-    - build-tools-27.0.3
+    - android-28
+    - build-tools-28.0.3
 
 env:
   global:

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext {
-    supportLibrary = "27.1.1"
+    supportLibrary = '1.0.0-beta01'
     kotlinVersion = '1.2.60'
   }
   repositories {
@@ -26,9 +26,9 @@ task clean(type: Delete) {
 }
 
 ext {
-  compileSdkVersion = 27
+  compileSdkVersion = 28
   minSdkVersion = 16
-  targetSdkVersion = 27
+  targetSdkVersion = 28
   versionCode = 13
   versionName = "1.3.2"
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -31,5 +31,5 @@ android {
 
 dependencies {
   implementation project(':launcher-kotlin')
-  implementation "com.android.support:appcompat-v7:$supportLibrary"
+  implementation "androidx.appcompat:appcompat:$supportLibrary"
 }

--- a/example/src/main/java/com/droibit/android/customtabs/launcher/example/MainActivity.kt
+++ b/example/src/main/java/com/droibit/android/customtabs/launcher/example/MainActivity.kt
@@ -3,9 +3,9 @@ package com.droibit.android.customtabs.launcher.example
 import android.content.ActivityNotFoundException
 import android.net.Uri
 import android.os.Bundle
-import android.support.customtabs.CustomTabsIntent
-import android.support.v4.content.ContextCompat
-import android.support.v7.app.AppCompatActivity
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.content.ContextCompat
+import androidx.appcompat.app.AppCompatActivity
 import android.view.View
 import android.widget.Toast
 import com.droibit.android.customtabs.launcher.CustomTabsLauncher

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.enableJetifier=true
+android.useAndroidX=true

--- a/launcher-kotlin/src/main/java/com/droibit/android/customtabs/launcher/CustomTabsLauncherExt.kt
+++ b/launcher-kotlin/src/main/java/com/droibit/android/customtabs/launcher/CustomTabsLauncherExt.kt
@@ -2,7 +2,7 @@ package com.droibit.android.customtabs.launcher
 
 import android.content.Context
 import android.net.Uri
-import android.support.customtabs.CustomTabsIntent
+import androidx.browser.customtabs.CustomTabsIntent
 
 /**
  * Opens the URL on a Custom Tab if possible. Otherwise fallback to opening it on a WebView.

--- a/launcher/build.gradle
+++ b/launcher/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-  api "com.android.support:customtabs:$supportLibrary"
+  api "androidx.browser:browser:$supportLibrary"
 
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.mockito:mockito-core:2.15.0'

--- a/launcher/src/main/java/com/droibit/android/customtabs/launcher/ChromePackage.java
+++ b/launcher/src/main/java/com/droibit/android/customtabs/launcher/ChromePackage.java
@@ -1,6 +1,6 @@
 package com.droibit.android.customtabs.launcher;
 
-import android.support.annotation.RestrictTo;
+import androidx.annotation.RestrictTo;
 import java.util.Arrays;
 import java.util.List;
 

--- a/launcher/src/main/java/com/droibit/android/customtabs/launcher/CustomTabsFallback.java
+++ b/launcher/src/main/java/com/droibit/android/customtabs/launcher/CustomTabsFallback.java
@@ -2,8 +2,8 @@ package com.droibit.android.customtabs.launcher;
 
 import android.content.Context;
 import android.net.Uri;
-import android.support.annotation.NonNull;
-import android.support.customtabs.CustomTabsIntent;
+import androidx.annotation.NonNull;
+import androidx.browser.customtabs.CustomTabsIntent;
 
 /**
  * To be used as a fallback to open the Uri when Custom Tabs is not available.

--- a/launcher/src/main/java/com/droibit/android/customtabs/launcher/CustomTabsLauncher.java
+++ b/launcher/src/main/java/com/droibit/android/customtabs/launcher/CustomTabsLauncher.java
@@ -3,14 +3,14 @@ package com.droibit.android.customtabs.launcher;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.RestrictTo;
-import android.support.annotation.Size;
-import android.support.customtabs.CustomTabsIntent;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
+import androidx.annotation.Size;
+import androidx.browser.customtabs.CustomTabsIntent;
 import java.util.List;
 
-import static android.support.annotation.RestrictTo.Scope.LIBRARY;
+import static androidx.annotation.RestrictTo.Scope.LIBRARY;
 import static com.droibit.android.customtabs.launcher.ChromePackage.CHROME_PACKAGES;
 
 /**

--- a/launcher/src/main/java/com/droibit/android/customtabs/launcher/CustomTabsLauncherImpl.java
+++ b/launcher/src/main/java/com/droibit/android/customtabs/launcher/CustomTabsLauncherImpl.java
@@ -6,16 +6,16 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Build;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.RestrictTo;
-import android.support.annotation.VisibleForTesting;
-import android.support.customtabs.CustomTabsIntent;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
+import androidx.annotation.VisibleForTesting;
+import androidx.browser.customtabs.CustomTabsIntent;
 import java.util.ArrayList;
 import java.util.List;
 
 import static android.content.Intent.ACTION_VIEW;
-import static android.support.annotation.RestrictTo.Scope.LIBRARY;
+import static androidx.annotation.RestrictTo.Scope.LIBRARY;
 
 @RestrictTo(LIBRARY) class CustomTabsLauncherImpl {
 

--- a/launcher/src/test/java/com/droibit/android/customtabs/launcher/CustomTabsLauncherImplTest.java
+++ b/launcher/src/test/java/com/droibit/android/customtabs/launcher/CustomTabsLauncherImplTest.java
@@ -3,7 +3,7 @@ package com.droibit.android.customtabs.launcher;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.net.Uri;
-import android.support.customtabs.CustomTabsIntent;
+import androidx.browser.customtabs.CustomTabsIntent;
 import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;


### PR DESCRIPTION
Support for androidX with updated compile and target version bumped up to 28 in order to add support for AndroidX in the flutter library (see https://github.com/droibit/flutter_custom_tabs/pull/11).
Example worked perfect for me after upgrade!