### PR TITLE
Fix to open intent in browser matching given package name, if not mat…

### DIFF
--- a/launcher/src/main/java/com/droibit/android/customtabs/launcher/internal/CustomTabsLauncherImpl.kt
+++ b/launcher/src/main/java/com/droibit/android/customtabs/launcher/internal/CustomTabsLauncherImpl.kt
@@ -14,7 +14,8 @@ internal class CustomTabsLauncherImpl {
         expectCustomTabsPackages: List<String>,
         fallback: CustomTabsFallback?
     ) {
-        val customTabsPackage = CustomTabsClient.getPackageName(context, expectCustomTabsPackages)
+        val customTabsPackage =
+            CustomTabsClient.getPackageName(context, expectCustomTabsPackages, true)
         if (customTabsPackage == null && fallback != null) {
             fallback.openUrl(context, uri, customTabsIntent)
             return


### PR DESCRIPTION
Before this fix, the url was always opening in the default browser. After this fix, it will try to open with chrome first, if chrome is not available and another preferred browser packagaName is given, it will try to open in the preferred browser. If not, it will open in the default browser.