### PR TITLE
Bump minSdk to 23 to align with androidx.browser:browser dependency

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@
 CustomTabsLauncher is a lightweight Android library that reliably launches
 [Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs) and
 Auth Tab by explicitly resolving the correct browser package before launching.
-It targets API 19+.
+It targets API 23+.
 
 Modules:
 

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -14,7 +14,7 @@ android {
   compileSdk = libs.versions.compileSdk.get().toInt()
 
   defaultConfig {
-    minSdk = 19
+    minSdk = 23
   }
 
   compileOptions {


### PR DESCRIPTION
- Update CustomTabsLauncher minSdk from 19 to 23
- Update copilot-instructions.md to reflect API 23+ targeting
- androidx.browser:browser requires minSdk 23, so CustomTabsLauncher's minimum SDK must be updated to match the dependency requirement