### PR TITLE
Bump version to 4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CustomTabsLauncher
 
 [![Android CI](https://github.com/droibit/CustomTabsLauncher/actions/workflows/android.yml/badge.svg)](https://github.com/droibit/CustomTabsLauncher/actions/workflows/android.yml)
-[![Download](https://img.shields.io/maven-central/v/io.github.droibit/customtabslauncher/4.0.0)](https://central.sonatype.com/artifact/io.github.droibit/customtabslauncher/4.0.0)
+[![Download](https://img.shields.io/maven-central/v/io.github.droibit/customtabslauncher/4.1.0)](https://central.sonatype.com/artifact/io.github.droibit/customtabslauncher/4.1.0)
 [![Software License](https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg)](https://github.com/droibit/prefbinding/blob/develop/LICENSE)
 
 This library makes it easy to

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 # Maven
 GROUP=io.github.droibit
-VERSION_NAME=4.0.0
+VERSION_NAME=4.1.0
 SONATYPE_HOST=CENTRAL_PORTAL
 SONATYPE_AUTOMATIC_RELEASE=true
 RELEASE_SIGNING_ENABLED=true


### PR DESCRIPTION
This pull request updates the project version from 4.0.0 to 4.1.0. The most important changes are:

Version bump:

* Updated the Maven version badge and artifact links in `README.md` to reference version 4.1.0 instead of 4.0.0.
* Changed the `VERSION_NAME` property in `gradle.properties` from 4.0.0 to 4.1.0 to reflect the new release version.